### PR TITLE
Add coread (共读室) to Shared Activities & Media / Reading & Film

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,7 @@ Tools for reading, watching, listening, journaling, focusing, or generating prom
 - [Duetto](https://github.com/avisforevelyn/Duetto) - Self-hostable listen-together player for two; AI companion that remembers every song you've shared. MIT. `JavaScript` · `Self-host` · `adapt`
 - [whale-browser-extension](https://github.com/whale-Yd00/whale-Yd00-whale-browser-extension) - Browser extension that lets an AI companion read webpage content alongside you, with selective text extraction and injection; built as the bridge for the whale/SullyOS ecosystem. MIT. `JavaScript` · `Browser` · `adapt`
 - [echo-reading](https://github.com/plustar35/echo-reading) - Deep reading notebook skeleton for Claude Code. Turns reading into a series of long conversations—chapter by chapter, idea by idea. `JavaScript` · `Claude Code` · `adapt`
+- [coread (共读室)](https://github.com/meowmana/coread) - Co-reading room where human and AI annotate the same book side by side: epub import with chapter and image extraction, CSS-column pagination that adapts from phone to desktop, shared highlights, comments and replies, reading presence, epub/markdown export with annotations, and MCP tools over stdio or SSE/Streamable HTTP. SQLite only, zero external dependencies. MIT. `TypeScript` · `Self-host` · `ready`
 
 ### Music & Listening Together
 


### PR DESCRIPTION
Adds [coread](https://github.com/meowmana/coread) — a co-reading room where a human and an AI companion read the same epub and leave annotations side by side on the page margin.

Checked against the inclusion criteria:
- Open source, MIT licensed
- Built for a long-term human–AI companion setup (shared bookshelf, reading presence, annotation replies accumulate over time)
- Description is based on the README and code: epub import (chapters/images/cover), CSS-column pagination, shared highlights/comments/replies, presence and notifications, epub/markdown export, MCP tools over stdio and SSE/Streamable HTTP, SQLite storage with zero external dependencies
- `ready`: npm install / build / start is the whole setup, no third-party services to configure

Disclosure: I'm the author of the project.