### PR TITLE
Add Local Waifu to Companion Clients & Workspaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Chat clients, local workspaces, and web apps for day-to-day interaction with a c
 - [Pando](https://github.com/Eloise-Aspen/pando-bridge) - Self-hosted mobile/PWA gateway for a local Claude Code CLI: WebSocket streaming of reasoning and tool use, file uploads, SQLite history, and permission approval. No built-in auth. MIT. `Python` · `Self-host` · `adapt`.
 - [CC Companion App](https://github.com/tjing9430/cc-companion-app) - Lightweight self-hosted companion chat starter with private/group chat, persistent memory notes, SSE updates, and PWA access. A compact reference for building a companion frontend. `JavaScript` · `Self-host` · `adapt`.
 - [ackem](https://github.com/JasonLiu0826/ackem) - Local-first AI desktop companion (Electron): privacy-first memory, emotion engine, extensions. Deeply tied to the author's own canon — strip the personal content before reuse. AGPLv3. `TypeScript` · `Cross-platform` · `adapt`.
+- [Local Waifu](https://github.com/lumizone/local-waifu) - Packaged offline desktop companion for macOS and Windows: bundled local LLM runtime, semantic long-term memory with an auto-built knowledge graph of the people and places in your life, on-device image generation for selfies, image understanding, voice, a seven-stage bond model with a live mood state, and encrypted per-character files that export to another machine. Ships as signed prebuilt releases; no client source, one-time paid license. `Rust/TypeScript` · `macOS/Windows` · `ready`.
 
 ---
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -65,6 +65,7 @@
 - [Pando](https://github.com/Eloise-Aspen/pando-bridge) - 可自托管的 Claude Code CLI 手机/PWA 网关：流式返回思考与工具调用、图片/PDF 上传、SQLite 记录、可插拔记忆和手机端权限审批。无内置鉴权。MIT。 `Python` · `Self-host` · `adapt`
 - [CC Companion App](https://github.com/tjing9430/cc-companion-app) - 轻量自托管陪伴聊天前端：私聊/群聊、持久记忆便笺、SSE 更新和 PWA 访问。适合作为围绕任意 Agent 适配器搭建陪伴前端的紧凑参考。 `JavaScript` · `Self-host` · `adapt`
 - [ackem](https://github.com/JasonLiu0826/ackem) - 本地优先 AI 桌面陪伴（Electron）：隐私优先的记忆、情绪引擎、扩展。深度绑定作者个人设定，复用前需先剥离个人内容。AGPLv3。`TypeScript` · `Cross-platform` · `adapt`
+- [Local Waifu](https://github.com/lumizone/local-waifu) - macOS/Windows 离线桌面陪伴应用：内置本地 LLM 运行时、语义长期记忆与自动构建的人物/地点知识图谱、本地出图自拍、图像理解、语音，以及七阶段关系模型和实时情绪状态，角色文件加密且可导出到其他机器。以签名预编译版本发布，不含客户端源码，一次性付费授权。`Rust/TypeScript` · `macOS/Windows` · `ready`
 
 ---
 


### PR DESCRIPTION
Adds [Local Waifu](https://github.com/lumizone/local-waifu) to **Companion Clients & Workspaces**.

### What it is

A packaged desktop companion for macOS and Windows that runs the whole stack locally: bundled LLM runtime, on-device image generation for selfies, image understanding, and voice. Nothing is required to leave the machine — it keeps working with every outbound connection blocked.

Relevant to this list specifically:

- **Long-term memory** — semantic recall plus an auto-built knowledge graph of the people and places from the conversation, distilled into a digest carried into each reply. Survives restarts and model swaps.
- **Identity & affect state** — seven-stage bond progression on earned XP, a live six-dimensional mood that decays toward baseline, and 13 conversational modes.
- **Continuity / data ownership** — each character is an encrypted file on your own disk that exports and moves to another machine. No account, no telemetry.
- Multiple characters with separate conversations and separate memory; 8-axis personality builder; 7 UI/reply languages.

### On the inclusion criteria

Being straight about it: this is **not open source**. It ships as signed prebuilt releases with no client source, under a one-time paid license, so it sits in the same bucket as [Miru](https://github.com/kiyotakali/Miru) — packaged binaries, described from public documentation. I flagged that plainly in the entry text ("Ships as signed prebuilt releases; no client source, one-time paid license") rather than glossing over it, and I'm fine with the entry being dropped or restatused if that reads as too far outside the bar.

Status is `ready` because it installs and runs as a finished app; happy to change it to `adapt` or `verify` if you prefer.

### Notes

- `README.zh-CN.md` updated with a matching entry.
- `npx awesome-lint` reports no content errors. The single failure is `Awesome list must reside in a valid git repository`, which the rule raises on any fork clone.
- Disclosure: I'm the author of the project.