### PR TITLE
Add DeepSeek酱语录 (DeepSeek whale-girl sticker gallery) to Sticker Libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ Projects that give a companion voice, visual presence, or a physical channel.
 ### Sticker Libraries (表情包库)
 
 - [astrbot_plugin_meme_manager](https://github.com/anka-afk/astrbot_plugin_meme_manager) - Sticker manager plugin for AstrBot: AI picks and sends stickers by emotion tags, WebUI management, cloud sync. `Python` · `AstrBot` · `ready`.
+- [DeepSeek酱语录 (DeepSeek-chan Meme Pack)](https://ai-meme.cdqyfdbymn.me/) - DeepSeek whale-girl sticker gallery: 128 curated quote-caption memes (蓝色大肥鱼/鲸鱼娘), WebP preview+original, tag filters, one-click share-card export, updated with new model releases. `Web` · `DeepSeek` · `live`.
 
 ---
 


### PR DESCRIPTION
Adds [DeepSeek酱语录](https://ai-meme.cdqyfdbymn.me/) — a DeepSeek whale-girl (蓝色大肥鱼) sticker gallery — to the **Sticker Libraries (表情包库)** section.

- 128 curated stickers with quote-level captions (『原来是高等模型』『涨价大模型给我跪下！』 etc.)
- WebP preview + original dual format, tag filters, dark mode, one-click share-card export
- Actively maintained, updated with each new DeepSeek model release
- Free to use, attribution/credit noted on site

Bilingual site (zh-CN). Thanks for reviewing!