### PR TITLE
Add local-ai-girlfriend (measured VRAM/latency budget + pivot-frame clip player)

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ Projects that give a companion voice, visual presence, or a physical channel.
 - [astrbot_plugin_chuanhuatong (传画筒)](https://github.com/bvzrays/astrbot_plugin_chuanhuatong) - Renders AstrBot text replies as Galgame-style chat frames with character sprites, emotion variants, layered text, and a drag-and-drop WebUI layout editor. `Python` · `AstrBot` · `ready`.
 - [Shinsekai](https://github.com/RachelForster/Shinsekai) - Local AI companion / visual-novel stage platform: persona-driven dialogue with TTS/ASR, memory, plugins, and galgame-style presentation. `Python` · `Cross-platform` · `ready`.
 - [pelle-d-umore](https://github.com/29-Cu/pelle-d-umore) - Emotional skin for AI chat: LLM persona drives the UI with inline text effects and full-screen mood skins. CC BY 4.0. `CSS` · `Web` · `adapt`.
+- [local-ai-girlfriend](https://github.com/tangyistudio/local-ai-girlfriend) - Measured VRAM and latency budget for a companion stack on one consumer GPU (cloned-voice TTS + lip-sync + local 8B): per-tier configurations for 8/16/24/32 GB, and the harness that produced every figure with the raw readings committed. Also ships a dependency-free player for pivot-frame clip libraries - cutting between pre-rendered clips without a visible seam - plus two checkers for the library itself. Demo character is all-rights-reserved; code is MIT plus an attribution clause. Docs are EN + Traditional Chinese. `Python/JavaScript` · `Self-host` · `ready`.
 
 ### Physical Devices & Touch
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -170,6 +170,7 @@
 - [astrbot_plugin_chuanhuatong (传画筒)](https://github.com/bvzrays/astrbot_plugin_chuanhuatong) - 把 AstrBot 纯文本回复渲染成带立绘的 Galgame 风聊天框图片：情绪差分、多层文本、拖拽式 WebUI 布局。`Python` · `AstrBot` · `ready`
 - [Shinsekai](https://github.com/RachelForster/Shinsekai) - 本地 AI 伴侣/视觉小说演出平台：人设驱动对话，含 TTS/ASR、记忆、插件和 Galgame 式演出。`Python` · `Cross-platform` · `ready`
 - [pelle-d-umore](https://github.com/29-Cu/pelle-d-umore) - AI 聊天情绪皮肤：AI 人格驱动 UI，行内文字特效+全屏情绪皮肤。CC BY 4.0。`CSS` · `Web` · `adapt`
+- [local-ai-girlfriend](https://github.com/tangyistudio/local-ai-girlfriend) - 在单张消费级显卡上实测的伴侣栈显存与延迟账单（克隆音色 TTS + 对口型 + 本地 8B）：8/16/24/32 GB 分级配置，以及产出每个数字的测量脚本，原始读数一并提交。另附零依赖播放器，用于枢纽帧片段库——在预渲染片段之间硬切而看不出接缝——以及两个片段库自检工具。示范角色版权保留；代码为 MIT 外加署名条款。文档为英文 + 繁体中文。 `Python/JavaScript` · `Self-host` · `ready`
 
 ### 物理设备与触觉
 


### PR DESCRIPTION
Adds a measurement-first entry to **Visual Presence & VTuber-Style Companions**, in both README.md and README.zh-CN.md.

**What it is:** the VRAM and latency bill for running a companion stack on one consumer GPU (cloned-voice TTS + lip-sync + a local 8B), measured rather than estimated. Per-tier configurations for 8/16/24/32 GB, and the harness that produced every figure is in `bench/` with the raw readings committed to `bench/results.json`, so the numbers can be checked rather than trusted.

**Also ships** `player/`: a dependency-free double-buffered video player for pivot-frame clip libraries - the seam problem when hard-cutting between short pre-rendered avatar clips - with 18 tests and two library checkers.

**How it differs from Ghost Vessel**, the nearest existing entry: that one is a reference implementation for attaching a pre-rendered video avatar. This one is primarily the measured budget for the whole stack, and the player is the part that solves the seam rather than the deliverable itself.

**Notes for review:**
- Status `ready`: the player, its tests and the checkers all run from a bare clone. The service layer needs your own model weights, which the docs state.
- Honest caveats, matching how this list handles them: the demo character's footage is all-rights-reserved and carved out of the code licence, so it is not a reusable asset pack. The code is MIT **plus** a mandatory attribution clause, not stock MIT - stated in the README rather than buried.
- Unverified figures are labelled in-repo (`recorded` / `session` / `source`), and retractions are left visible rather than deleted.
- Docs are English + Traditional Chinese; I wrote the zh-CN entry in Simplified for README.zh-CN.md.
- `npx awesome-lint` fails with `Invalid GitHub repo URL` on my clone - but it fails identically on an unmodified `main`, so it looks like a fork-context issue rather than anything my two lines introduced. Happy to re-run however you normally do it.