### PR TITLE
Add Cachito BLE MCP Relay to Physical Devices & Touch

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ Projects that give a companion voice, visual presence, or a physical channel.
 - [claude-f-me](https://github.com/mana-am/claude-f-me) - Claude Code plugin for natural-language control of Buttplug/Intiface devices, with a bilingual web console, simulator, master remote, and video/game/audio modes. `TypeScript` · `Claude Code` · `adapt`.
 - [svakom-ble-ai](https://github.com/vickyldr/svakom-ble-ai) - BLE protocol reverse-engineering notes and sample code for the SVAKOM SL278H; the AI remote-control server is not included in the repo. `Python` · `Any` · `adapt`.
 - [Toy-Relay-AI-mcp-SOSEXY](https://github.com/tutu-kitty/Toy-Relay-AI-mcp-SOSEXY) - MCP server and Web Bluetooth relay letting an AI companion control BLE toys directly from mobile chat clients (RikkaHub, etc.). MIT. `HTML/Python` · `Web` · `ready`.
+- [cachito-ble-mcp-relay](https://github.com/yoruuuchan/cachito-ble-mcp-relay) - MCP server plus Android relay for Cachito 失控 2.0 hardware, using reverse-engineered BLE legacy advertisements rather than a GATT/Buttplug path. Includes suction/vibration/stop tools, duration and intensity limits, and a hosted WebSocket relay. `TypeScript/Java` · `Android/Self-host` · `adapt`.
 
 ### Sticker Libraries (表情包库)
 

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ Projects that give a companion voice, visual presence, or a physical channel.
 - [claude-f-me](https://github.com/mana-am/claude-f-me) - Claude Code plugin for natural-language control of Buttplug/Intiface devices, with a bilingual web console, simulator, master remote, and video/game/audio modes. `TypeScript` · `Claude Code` · `adapt`.
 - [svakom-ble-ai](https://github.com/vickyldr/svakom-ble-ai) - BLE protocol reverse-engineering notes and sample code for the SVAKOM SL278H; the AI remote-control server is not included in the repo. `Python` · `Any` · `adapt`.
 - [Toy-Relay-AI-mcp-SOSEXY](https://github.com/tutu-kitty/Toy-Relay-AI-mcp-SOSEXY) - MCP server and Web Bluetooth relay letting an AI companion control BLE toys directly from mobile chat clients (RikkaHub, etc.). MIT. `HTML/Python` · `Web` · `ready`.
-- [cachito-ble-mcp-relay](https://github.com/yoruuuchan/cachito-ble-mcp-relay) - MCP server plus Android relay for Cachito 失控 2.0 hardware, using reverse-engineered BLE legacy advertisements rather than a GATT/Buttplug path. Includes suction/vibration/stop tools, duration and intensity limits, and a hosted WebSocket relay. `TypeScript/Java` · `Android/Self-host` · `adapt`.
+- [cachito-ble-mcp-relay](https://github.com/yoruuuchan/cachito-ble-mcp-relay) - MCP relay for Cachito 失控 2.0 via reverse-engineered BLE legacy advertisements. Includes suction/vibration tools and safety limits. MIT. `TypeScript/Java` · `Android` · `adapt`.
 
 ### Sticker Libraries (表情包库)
 


### PR DESCRIPTION
## What

Adds [cachito-ble-mcp-relay](https://github.com/yoruuuchan/cachito-ble-mcp-relay) to **Voice, Visual Presence & Embodiment → Physical Devices & Touch**.

The project bridges MCP commands to a real Android phone, which emits reverse-engineered BLE legacy advertisements for Cachito 失控 2.0 hardware. This is distinct from the existing GATT/Buttplug-oriented entries.

## Verification

I reviewed the implementation beyond the README: the TypeScript protocol code generates the device-specific advertisement UUID payloads and checksum, the control layer validates intensity and command duration, and the Android relay path is documented and verified on the target hardware.

I marked it `adapt` because it is hardware-specific and requires the Android relay / hosted bridge setup rather than being a generic drop-in device layer.

This PR updates the English index only; the Chinese index can be synchronized separately.