### PR TITLE
Add murmur to Companion Clients & Workspaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Chat clients, local workspaces, and web apps for day-to-day interaction with a c
 - [mousecrew](https://github.com/anqinou-art/mousecrew) - Hamster-crew work board and group chat for CLI coding agents: @mention wakeups, 9-state work orders, self-scheduling, Git verification, and a merge gate. MIT. `JavaScript` · `CLI` · `ready`.
 - [yoji](https://github.com/wangxijie001/yoji) - Emotion-aware desktop AI companion: local voice wake, floating widget, mood drift, MCP tool calling, and office assistance. MIT. `TypeScript` · `Cross-platform` · `ready`.
 - [Cyrene-Agent](https://github.com/Playa-0v0/Cyrene-Agent) - Desktop agent on the Cyrene_Harness framework: immersive persona chat, desktop assistance, learning, music, and weather tools. MIT. `TypeScript` · `Cross-platform` · `adapt`.
+- [murmur](https://github.com/wine-fall/murmur) - Always-on AI radio host for the terminal: picks its own topics, talks, plays music, and answers typed replies in a natural-sounding voice. Needs a Claude Code login and a hosted fish-speech endpoint. `TypeScript` · `Terminal` · `ready`.
 
 ---
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -69,6 +69,7 @@
 - [mousecrew](https://github.com/anqinou-art/mousecrew) - 仓鼠团队形象的 CLI 编码 Agent 群聊与工单看板：支持 @唤醒、9 状态工单流、依赖自调度、Git 提交校验与单合并门禁。MIT。`JavaScript` · `CLI` · `ready`。
 - [yoji](https://github.com/wangxijie001/yoji) - 有情绪的开源桌面 AI 伴侣：支持本地语音唤醒、悬浮挂件、情绪漂移、MCP 无限扩展与日常办公协助。MIT。`TypeScript` · `Cross-platform` · `ready`。
 - [Cyrene-Agent](https://github.com/Playa-0v0/Cyrene-Agent) - 基于 Cyrene_Harness 框架的桌面智能体：兼顾沉浸式昔涟人设陪伴、办公编程辅助与音乐天气等多工具扩展。MIT。`TypeScript` · `Cross-platform` · `adapt`。
+- [murmur](https://github.com/wine-fall/murmur) - 常驻终端的 AI 电台主播：自己挑话题开口聊、放歌、回来接着播；你打字回它，它用接近真人的声音回答；一位主播，对你的记忆会随相处加深。需要 Claude Code 登录和一个托管的 fish-speech 端点。MIT。`TypeScript` · `Terminal` · `ready`
 
 ---
 


### PR DESCRIPTION
## What

Adds **murmur** to *Companion Clients & Workspaces* (bottom of the section), in both `README.md` and `README.zh-CN.md`.

> murmur - Always-on AI radio host for the terminal: picks its own topics, talks, plays music, and answers typed replies in a natural-sounding voice. Needs a Claude Code login and a hosted fish-speech endpoint. `TypeScript` · `Terminal` · `ready`.

## Why it fits this list

It is built for a long-term companion setup rather than one-shot chat: one host whose character is written to a plain text file on the first run and then holds; what changes over time is its memory of the listener (profile, topics discussed, songs played, an anti-repeat log). It broadcasts on its own and comes back to you, so it is a companion that stays present rather than a chatbot that waits.

## Code verification (I am the author, so read this as a self-report against the code, not the README)

- Engine: `src/director/` runs the program loop (talk / music / time anchors); `src/brain/` wraps a Claude session via `@anthropic-ai/claude-agent-sdk` with murmur-owned tools; `src/audio/` is a Web Audio graph on `node-web-audio-api` that mixes voice over music with gain ducking.
- Memory: `~/.murmur/` holds the persona file (written once at setup, user-editable), a profile that is folded from conversation logs, topic and song ledgers.
- Voice: a `VoiceProvider` seam; v1 is a hosted fish-speech endpoint the user points it at. No local TTS is shipped, which is why the description says so.
- Boundaries stated plainly: it is not offline and not self-contained; the brain, the voice, and the music all come off the network.
- Status `ready`: published on npm (0.2.1), installable with one command, documented install and usage, tests and CI on every PR.

## Checklist

- Searched the list for duplicates: no terminal radio-style companion is listed; the nearest neighbours are the Claude Code channel tools in the same section.
- Entry description is 199 characters, ends with punctuation, uses the existing language / platform / readiness metadata format.
- Chinese translation added to `README.zh-CN.md` (I am a native speaker).
- `npx awesome-lint`: no content findings for the new line. On the local branch it prints only the `awesome-github` repository check, which passes on `main` of the same clone.

**About murmur** (for review): https://github.com/wine-fall/murmur — MIT, TypeScript, Node >= 24. `npm install -g murmur-radio && murmur`. Landing page: https://wine-fall.github.io/murmur/. First commit 2026-06-29, 200+ commits on main, npm 0.2.1 published 2026-09-02. Small so far: 3 GitHub stars, about 800 npm downloads a month. It needs a Claude Code login (the brain is a Claude session through the Claude Agent SDK) and a hosted fish-speech endpoint for the voice; music streams through yt-dlp.

Drafted with [Claude Code](https://claude.com/claude-code).

https://claude.ai/code/session_01Qa4kN17uYSPQZJc6ovwUZb
